### PR TITLE
Add ~/.local/bin and ~/bin to default PATH

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+galliumos-default-settings (2.3) xenon; urgency=medium
+
+  * Add ~/.local/bin and ~/bin to default PATH
+
+ -- David Muckle <dvdmuckle@galliumos.org>  Wed, 17 May 2017 18:56:40 -0400
+
 galliumos-default-settings (2.2) xenon; urgency=medium
 
   * Made Ctrl Alt T shorcut for xfce4-terminal

--- a/etc/skel/.profile
+++ b/etc/skel/.profile
@@ -1,0 +1,20 @@
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
+# exists.
+# see /usr/share/doc/bash/examples/startup-files for examples.
+# the files are located in the bash-doc package.
+
+# the default umask is set in /etc/profile; for setting the umask
+# for ssh logins, install and configure the libpam-umask package.
+#umask 022
+
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+	# include .bashrc if it exists
+	if [ -f "$HOME/.bashrc" ]; then
+		. "$HOME/.bashrc"
+	fi
+fi
+
+# set PATH so it includes user's private bin directories
+PATH="$HOME/bin:$HOME/.local/bin:$PATH"

--- a/etc/skel/.profile
+++ b/etc/skel/.profile
@@ -17,4 +17,4 @@ if [ -n "$BASH_VERSION" ]; then
 fi
 
 # set PATH so it includes user's private bin directories
-PATH="$HOME/bin:$HOME/.local/bin:$HOME/.bin:$PATH"
+PATH="$HOME/bin:$HOME/.local/bin:$PATH"

--- a/etc/skel/.profile
+++ b/etc/skel/.profile
@@ -17,4 +17,4 @@ if [ -n "$BASH_VERSION" ]; then
 fi
 
 # set PATH so it includes user's private bin directories
-PATH="$HOME/bin:$HOME/.local/bin:$PATH"
+PATH="$HOME/bin:$HOME/.local/bin:$HOME/.bin:$PATH"


### PR DESCRIPTION
This was raised by a user over IRC. Current Ubuntu 16.04 `.profiles`s add ~/.local/bin and ~/bin to the default PATH, regardless of whether or not they actually exist.